### PR TITLE
python3 and image format fixes

### DIFF
--- a/idx2ndarray.py
+++ b/idx2ndarray.py
@@ -6,8 +6,9 @@ import time,math
 import struct as st
 import numpy as np
 
-trainingfilenames = {'images' : 'training_set/train-images.idx3-ubyte' ,'labels' : 'training_set/train-labels.idx1-ubyte'}
-testfilenames = {'images' : 'test_set/t10k-images.idx3-ubyte' ,'labels' : 'test_set/t10k-labels.idx1-ubyte'}
+trainingfilenames = {'images' : 'train-images-idx3-ubyte' ,'labels' : 'train-labels-idx1-ubyte'}
+
+testfilenames = {'images' : 't10k-images-idx3-ubyte' ,'labels' : 't10k-labels-idx1-ubyte'}
 
 data_types = {
         0x08: ('ubyte', 'B', 1),
@@ -18,13 +19,13 @@ data_types = {
         0x0E: ('>f8', 'd', 8)}
 
 #..........................................................For training dataset..............................................................
-print "Training Dataset......."
+print("Training Dataset.......")
 stime = time.time()
 for name in trainingfilenames.keys():
 	if name == 'images':
-		train_imagesfile = open(trainingfilenames[name],'r+')
+		train_imagesfile = open(trainingfilenames[name],'rb')
 	if name == 'labels':
-		train_labelsfile = open(trainingfilenames[name],'r+')
+		train_labelsfile = open(trainingfilenames[name],'rb')
 
 train_imagesfile.seek(0)
 magic = st.unpack('>4B',train_imagesfile.read(4))
@@ -33,13 +34,13 @@ if(magic[0] and magic[1])or(magic[2] not in data_types):
 
 #Information
 nDim = magic[3]
-print "Data is "+str(nDim)+"-D"
+print("Data is "+str(nDim)+"-D")
 dataType = data_types[magic[2]][0]
-print "Data Type :: ",dataType
+print("Data Type :: ",dataType)
 dataFormat = data_types[magic[2]][1]
-print "Data Format :: ",dataFormat
+print("Data Format :: ",dataFormat)
 dataSize = data_types[magic[2]][2]
-print "Data Size :: "+str(dataSize)+" byte\n"
+print("Data Size :: "+str(dataSize)+" byte\n")
 
 #offset = 0004 for number of images
 #offset = 0008 for number of rows
@@ -51,22 +52,22 @@ nR = st.unpack('>I',train_imagesfile.read(4))[0] #num of rows
 nC = st.unpack('>I',train_imagesfile.read(4))[0] #num of columns
 
 train_labelsfile.seek(8) #Since no. of items = no. of images and is already read
-print "no. of images :: ",nImg
-print "no. of rows :: ",nR
-print "no. of columns :: ",nC
-print
+print("no. of images :: ",nImg)
+print("no. of rows :: ",nR)
+print("no. of columns :: ",nC)
+print()
 #Training set
 #Reading the labels
-train_labels_array = np.asarray(st.unpack('>'+dataFormat*nImg,train_labelsfile.read(nImg*dataSize))).reshape((nImg,1))
+train_labels_array = np.asarray(st.unpack('>'+dataFormat*nImg,train_labelsfile.read(nImg*dataSize)),dtype=np.uint8).reshape((nImg,1))
 #Reading the Image data
 nBatch = 10000
 nIter = int(math.ceil(nImg/nBatch))
 nBytes = nBatch*nR*nC*dataSize
 nBytesTot = nImg*nR*nC*dataSize
-train_images_array = np.array([])
-for i in xrange(0,nIter):
+train_images_array = np.array([], dtype=np.uint8)
+for i in range(0,nIter):
 	#try:
-	temp_images_array = 255 - np.asarray(st.unpack('>'+dataFormat*nBytes,train_imagesfile.read(nBytes))).reshape((nBatch,nR,nC))
+	temp_images_array = 255 - np.asarray(st.unpack('>'+dataFormat*nBytes,train_imagesfile.read(nBytes)),dtype=np.uint8).reshape((nBatch,nR,nC))
 	'''except:
 		nbytes = nBytesTot - (nIter-1)*nBytes
 		temp_images_array = 255 - np.asarray(st.unpack('>'+'B'*nbytes,train_imagesfile.read(nbytes))).reshape((nBatch,nR,nC))'''
@@ -75,31 +76,31 @@ for i in xrange(0,nIter):
 		train_images_array = temp_images_array
 	else:
 		train_images_array = np.vstack((train_images_array,temp_images_array))
-	temp_images_array = np.array([])
-	print "Time taken :: "+str(time.time()-stime)+" seconds\n"
-	print str((float(i+1)/nIter)*100)+"% complete...\n"
+	temp_images_array = np.array([], dtype=np.uint8)
+	print("Time taken :: "+str(time.time()-stime)+" seconds\n")
+	print(str((float(i+1)/nIter)*100)+"% complete...\n")
 
 
-print "Training Set Labels shape ::",train_labels_array.shape
-print "Training Set Image shape ::",train_images_array.shape
+print("Training Set Labels shape ::",train_labels_array.shape)
+print("Training Set Image shape ::",train_images_array.shape)
 
-print "Time of execution :: "+str(time.time()-stime)+" seconds\n"
+print("Time of execution :: "+str(time.time()-stime)+" seconds\n")
 #..........................................................For test dataset..................................................................
-print "Test Dataset......."
+print("Test Dataset.......")
 stime = time.time()
 for name in testfilenames.keys():
 	if name == 'images':
-		test_imagesfile = open(testfilenames[name],'r+')
+		test_imagesfile = open(testfilenames[name],'rb')
 	if name == 'labels':
-		test_labelsfile = open(testfilenames[name],'r+')
+		test_labelsfile = open(testfilenames[name],'rb')
 test_imagesfile.seek(0)
 magic = st.unpack('>4B',test_imagesfile.read(4))
 if(magic[0] and magic[1])or(magic[2] not in data_types):
 	raise ValueError("File Format not correct")
 
 nDim = magic[3]
-print "Data is ",nDim,"-D"
-print
+print("Data is ",nDim,"-D")
+print()
 #offset = 0004 for number of images
 #offset = 0008 for number of rows
 #offset = 0012 for number of columns
@@ -110,22 +111,22 @@ nR = st.unpack('>I',test_imagesfile.read(4))[0] #num of rows
 nC = st.unpack('>I',test_imagesfile.read(4))[0] #num of columns
 
 test_labelsfile.seek(8) #Since no. of items = no. of images and is already read
-print "no. of images :: ",nImg
-print "no. of rows :: ",nR
-print "no. of columns :: ",nC
-print
+print("no. of images :: ",nImg)
+print("no. of rows :: ",nR)
+print("no. of columns :: ",nC)
+print()
 #Test set
 #Reading the labels
-test_labels_array = np.asarray(st.unpack('>'+dataFormat*nImg,test_labelsfile.read(nImg*dataSize))).reshape((nImg,1))
+test_labels_array = np.asarray(st.unpack('>'+dataFormat*nImg,test_labelsfile.read(nImg*dataSize)),dtype=np.uint8).reshape((nImg,1))
 #Reading the Image data
 nBatch = 10000
 nIter = int(math.ceil(nImg/nBatch))
 nBytes = nBatch*nR*nC*dataSize
 nBytesTot = nImg*nR*nC*dataSize
-test_images_array = np.array([])
-for i in xrange(0,nIter):
+test_images_array = np.array([], dtype=np.uint8)
+for i in range(0,nIter):
 	#try:
-	temp_images_array = 255 - np.asarray(st.unpack('>'+dataFormat*nBytes,test_imagesfile.read(nBytes))).reshape((nBatch,nR,nC))
+	temp_images_array = 255 - np.asarray(st.unpack('>'+dataFormat*nBytes,test_imagesfile.read(nBytes)),dtype=np.uint8).reshape((nBatch,nR,nC))
 	'''except:
 		nbytes = nBytesTot - (nIter-1)*nBytes
 		temp_images_array = 255 - np.asarray(st.unpack('>'+'B'*nbytes,test_imagesfile.read(nbytes))).reshape((nBatch,nR,nC))'''
@@ -134,12 +135,12 @@ for i in xrange(0,nIter):
 		test_images_array = temp_images_array
 	else:
 		test_images_array = np.vstack((test_images_array,temp_images_array))
-	temp_images_array = np.array([])
-	print "Time taken :: "+str(time.time()-stime)+" seconds\n"
-	print str((float(i+1)/nIter)*100)+"% complete...\n"
+	temp_images_array = np.array([], dtype=np.uint8)
+	print("Time taken :: "+str(time.time()-stime)+" seconds\n")
+	print(str((float(i+1)/nIter)*100)+"% complete...\n")
 
 
-print "Test Set Labels shape ::",test_labels_array.shape
-print "Test Set Image shape ::",test_images_array.shape
+print("Test Set Labels shape ::",test_labels_array.shape)
+print("Test Set Image shape ::",test_images_array.shape)
 
-print "Time of execution : %s seconds" % str(time.time()-stime)
+print("Time of execution : %s seconds" % str(time.time()-stime))

--- a/idx2nparr.py
+++ b/idx2nparr.py
@@ -5,14 +5,14 @@ import struct as st
 import numpy as np
 
 filename = {'images' : 'train-images.idx3-ubyte' ,'labels' : 'train-labels.idx1-ubyte'}
-images_array = np.array([])
-labels_array = np.array([])
+images_array = np.array([], dtype=np.uint8)
+labels_array = np.array([], dtype=np.uint8)
 
 for name in filename.keys():
 	if name == 'images':
-		imagesfile = open(filename[name],'r+')
+		imagesfile = open(filename[name],'rb')
 	if name == 'labels':
-		labelsfile = open(filename[name],'r+')
+		labelsfile = open(filename[name],'rb')
 
 #offset = 0004 for number of images
 #offset = 0008 for number of rows
@@ -23,13 +23,13 @@ nImg = st.unpack('>I',imagesfile.read(4))[0] #num of images/labels
 nR = st.unpack('>I',imagesfile.read(4))[0] #num of rows
 nC = st.unpack('>I',imagesfile.read(4))[0] #num of columns
 labelsfile.seek(8) #Since no. of items = no. of images and is already read
-print "no. of images :: ",nImg
-print "no. of rows :: ",nR
-print "no. of columns :: ",nC
+print("no. of images :: ",nImg)
+print("no. of rows :: ",nR)
+print("no. of columns :: ",nC)
 
-temp_array = np.array([])
-images10000_array = np.array([])
-for i in xrange(1,nImg+1):
+temp_array = np.array([], dtype=np.uint8)
+images10000_array = np.array([], dtype=np.uint8)
+for i in range(1,nImg+1):
 	#Read labels
 	labels_array = np.append(labels_array,st.unpack('>B',labelsfile.read(1))[0])
 	#Read training images
@@ -42,7 +42,7 @@ for i in xrange(1,nImg+1):
 			temp_array = np.vstack((temp_array[None],nextimage[None]))
 		else:
 			temp_array = np.vstack((temp_array,nextimage[None]))
-	
+
 	#Extra stuffs to speed up the stacking process (took 51.804361105 seconds in my case)
 	#Stacking each 1000 block to form a block of 10000
 	if i%1000==0 and i != 0:
@@ -50,18 +50,18 @@ for i in xrange(1,nImg+1):
 			images10000_array = temp_array
 		else:
 			images10000_array = np.vstack((images10000_array,temp_array))
-		temp_array = np.array([])
-		print "Time taken :: ",time.time()-stime
+		temp_array = np.array([], dtype=np.uint8)
+		print("Time taken :: ",time.time()-stime)
 	#Stacking each 10000 block to form the whole dataset
-	if i%10000==0 and i != 0: 
+	if i%10000==0 and i != 0:
 		if images_array.size == 0:
 			images_array = images10000_array
 		else:
 			images_array = np.vstack((images_array,images10000_array))
-		images10000_array = np.array([])
-		print (float(i)/nImg)*100,"% complete..."
+                images10000_array = np.array([], dtype=np.uint8)
+		print((float(i)/nImg)*100,"% complete...")
 
-print labels_array.shape
-print images_array.shape
+print(labels_array.shape)
+print(images_array.shape)
 
-print "Time of execution : %s seconds" % str(time.time()-stime)
+print("Time of execution : %s seconds" % str(time.time()-stime))

--- a/idx2numpyarray.py
+++ b/idx2numpyarray.py
@@ -4,9 +4,9 @@ stime = time.time()
 import struct as st
 import numpy as np
 
-filename = {'images' : 'training_set/train-images.idx3-ubyte' ,'labels' : 'training_set/train-labels.idx1-ubyte'}
+filename = {'images' : 'train-images-idx3-ubyte' ,'labels' : 'train-labels-idx1-ubyte'}
 
-labels_array = np.array([])
+labels_array = np.array([], dtype=np.uint8)
 
 data_types = {
         0x08: ('ubyte', 'B', 1),
@@ -18,9 +18,9 @@ data_types = {
 
 for name in filename.keys():
 	if name == 'images':
-		imagesfile = open(filename[name],'r+')
+		imagesfile = open(filename[name],'rb')
 	if name == 'labels':
-		labelsfile = open(filename[name],'r+')
+		labelsfile = open(filename[name],'rb')
 
 imagesfile.seek(0)
 magic = st.unpack('>4B',imagesfile.read(4))
@@ -28,7 +28,7 @@ if(magic[0] and magic[1])or(magic[2] not in data_types):
 	raise ValueError("File Format not correct")
 
 nDim = magic[3]
-print "Data is ",nDim,"-D"
+print("Data is ",nDim,"-D")
 
 #offset = 0004 for number of images
 #offset = 0008 for number of rows
@@ -40,16 +40,16 @@ nR = st.unpack('>I',imagesfile.read(4))[0] #num of rows
 nC = st.unpack('>I',imagesfile.read(4))[0] #num of columns
 nBytes = nImg*nR*nC
 labelsfile.seek(8) #Since no. of items = no. of images and is already read
-print "no. of images :: ",nImg
-print "no. of rows :: ",nR
-print "no. of columns :: ",nC
+print("no. of images :: ",nImg)
+print("no. of rows :: ",nR)
+print("no. of columns :: ",nC)
 
 #Read all data bytes at once and then reshape
 images_array = 255 - np.asarray(st.unpack('>'+'B'*nBytes,imagesfile.read(nBytes))).reshape((nImg,nR,nC))
 labels_array = np.asarray(st.unpack('>'+'B'*nImg,labelsfile.read(nImg))).reshape((nImg,1))
 
-print labels_array
-print labels_array.shape
-print images_array.shape
+print(labels_array)
+print(labels_array.shape)
+print(images_array.shape)
 
-print "Time of execution : %s seconds" % str(time.time()-stime)
+print("Time of execution : %s seconds" % str(time.time()-stime))

--- a/ndarr2img.py
+++ b/ndarr2img.py
@@ -1,10 +1,11 @@
 import time
 import numpy as np
-from scipy.misc import imsave
+import imageio
+import warnings
 
 stime = time.time()
 from idx2ndarray import train_images_array,test_images_array,train_labels_array,test_labels_array
-print "\nTime for loading numpy arrays from idx2ndarray :: "+str(time.time()-stime)+" seconds\n"
+print("\nTime for loading numpy arrays from idx2ndarray :: "+str(time.time()-stime)+" seconds\n")
 
 trainImgshape = train_images_array.shape
 trainLabelshape = train_labels_array.shape
@@ -12,33 +13,37 @@ testImgshape = test_images_array.shape
 testLabelshape = test_labels_array.shape
 
 stime = time.time()
-training_folderName = 'training_set_images/'
+training_folderName = 'images/training/'
 fileNameLen = len(str(trainImgshape[0]))
 nIter = trainImgshape[0]+1
-for n in xrange(1,nIter):
-	filename = '0'*(fileNameLen - len(str(n)))+str(n)+'.jpg'
-	#print filename
-	imsave(training_folderName+filename,train_images_array[n-1,:,:])
-print "Time for converting training dataset array to images :: "+str(time.time()-stime)+" seconds\n"
+for n in range(1,nIter):
+    filename = '0'*(fileNameLen - len(str(n)))+str(n)+'.jpg'
+    #print(filename)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        imageio.imwrite(training_folderName+filename,train_images_array[n-1,:,:])
+print("Time for converting training dataset array to images :: "+str(time.time()-stime)+" seconds\n")
 
 stime = time.time()
-test_folderName = 'test_set_images/'
+test_folderName = 'images/test/'
 fileNameLen = len(str(testImgshape[0]))
 nIter = testImgshape[0]+1
-for n in xrange(1,nIter):
-	filename = '0'*(fileNameLen - len(str(n)))+str(n)+'.jpg'
-	#print filename
-	imsave(test_folderName+filename,test_images_array[n-1,:,:])
-print "Time for converting test dataset array to images :: "+str(time.time()-stime)+" seconds\n"
+for n in range(1,nIter):
+    filename = '0'*(fileNameLen - len(str(n)))+str(n)+'.jpg'
+    #print(filename)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        imageio.imwrite(test_folderName+filename,test_images_array[n-1,:,:])
+print("Time for converting test dataset array to images :: "+str(time.time()-stime)+" seconds\n")
 
 stime = time.time()
 trainingLabelFileName = 'training_set_labels'
 np.save(trainingLabelFileName,train_labels_array,allow_pickle=False,fix_imports=False)
-print "Time for saving Training Labels array as .npy file :: "+str(time.time()-stime)+" seconds\n"
+print("Time for saving Training Labels array as .npy file :: "+str(time.time()-stime)+" seconds\n")
 
 stime = time.time()
 testLabelFileName = 'test_set_labels'
 np.save(testLabelFileName,test_labels_array,allow_pickle=False,fix_imports=False)
-print "Time for saving Test Labels array as .npy file :: "+str(time.time()-stime)+" seconds\n"
+print("Time for saving Test Labels array as .npy file :: "+str(time.time()-stime)+" seconds\n")
 
 #saved as .npy


### PR DESCRIPTION
this should run with both python 2 and 3
also removed calls to imsave
forced format of np.arrays to uint8 to avoid warning messages